### PR TITLE
Door Hooks Added at Round Start and Stop

### DIFF
--- a/addons/sourcemod/scripting/smartjaildoors.sp
+++ b/addons/sourcemod/scripting/smartjaildoors.sp
@@ -371,20 +371,12 @@ public void OnMapStart()
 
 	if (!IsSoundPrecached(BUTTON_USE_SOUND))
 		PrecacheSound(BUTTON_USE_SOUND);
-	#if defined DOOR_HOOKS
-	ExecuteDoors(AddDoorHooks);
-	#endif
 }
 
 #if defined DOOR_HOOKS
 public void AddDoorHooks(const char[] name, const char[] clsname)
 {
 	HookDoorAction(name, clsname);
-}
-
-public void OnMapEnd()
-{
-	ExecuteDoors(RemoveDoorHooks);
 }
 
 public void RemoveDoorHooks(const char[] name, const char[] clsname)
@@ -747,6 +739,10 @@ void CreateButton(int buttonid, const float origin[3])
 public void OnRoundStart(Event event, const char[] name, bool dontBroadcast)
 {
 	ExecuteButtons(SpawnButtonsOnRoundStart);
+	
+	#if defined DOOR_HOOKS
+	ExecuteDoors(AddDoorHooks);
+	#endif
 }
 
 public void OnRoundEnd(Event event, const char[] name, bool dontBroadcast)
@@ -756,6 +752,10 @@ public void OnRoundEnd(Event event, const char[] name, bool dontBroadcast)
 		if (g_SJDMenu2 != null)
 			delete g_SJDMenu2;
 	}
+	
+	#if defined DOOR_HOOKS
+	ExecuteDoors(RemoveDoorHooks);
+	#endif
 }
 
 public void OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)


### PR DESCRIPTION
Fixes issue with door hooks not working after first round.  Looks like the HookSingleEntityOutput is unhooked after the round is over and entities are re-assigned.  Might not need to remove them on RoundEnd but might as well be safe.  Tested on server with no errors.
